### PR TITLE
Fixing yield in iter module

### DIFF
--- a/haloscans/haloscans.py
+++ b/haloscans/haloscans.py
@@ -40,8 +40,12 @@ class HaloScans(object):
     def __iter__(self):
         """Yields scans one at a time. Forever."""
         while True:
-            for scan in self.get_next_batch():
-                yield scan
+            scans = self.get_next_batch()
+            if scans:
+                for scan in scans:
+                    yield scan
+            else:
+                yield []
 
     def build_halo_session(self):
         """Instantiates the Halo session"""


### PR DESCRIPTION
It keep printing date in console for ever.
For ex:
2017-12-12T13:39:00.340Z
2017-12-12T13:39:00.340Z
2017-12-12T13:39:00.340Z
....
And there will be no way to stop the iterations.